### PR TITLE
Fixed Missed Phrase Error

### DIFF
--- a/Block/Checkout/UpdateLayoutProcessor.php
+++ b/Block/Checkout/UpdateLayoutProcessor.php
@@ -437,7 +437,7 @@ class UpdateLayoutProcessor implements LayoutProcessorInterface
 
                                                         ],
                                                         'region' => [
-                                                            'label' => new \Magento\Framework\Phrase(''),
+                                                            'label' => '',
                                                             'sortOrder' => 50,
                                                             'config' => [
                                                                 'template' => 'IWD_Opc/form/field',
@@ -854,14 +854,14 @@ class UpdateLayoutProcessor implements LayoutProcessorInterface
             $fieldConfig['config']['additionalClasses'] = 'float-left wd30-66 mr4';
             $fieldConfig['validation']['required-entry'] = true;
         } else if ($fieldCode === 'region') {
-            $fieldConfig['label'] = new \Magento\Framework\Phrase('');
+            $fieldConfig['label'] = '';
             $fieldConfig['visible'] = false;
             $fieldConfig['sortOrder'] = '50';
             $fieldConfig['config']['template'] = 'IWD_Opc/form/field-region';
             $fieldConfig['config']['additionalClasses'] = 'float-left wd30-66 mr4';
             $fieldConfig['config']['elementTmpl'] = 'IWD_Opc/form/element/input';
         } else if ($fieldCode === 'region_id') {
-            $fieldConfig['label'] = new \Magento\Framework\Phrase('');
+            $fieldConfig['label'] = '';
             $fieldConfig['sortOrder'] = '50';
             $fieldConfig['placeholder'] = '';
             $fieldConfig['component'] = 'IWD_Opc/js/form/element/region';

--- a/Block/Checkout/UpdateLayoutProcessor.php
+++ b/Block/Checkout/UpdateLayoutProcessor.php
@@ -446,7 +446,7 @@ class UpdateLayoutProcessor implements LayoutProcessorInterface
                                                         ],
                                                         'region_id' => [
                                                             'sortOrder' => 50,
-                                                            'placeholder' => __(''),
+                                                            'placeholder' => '',
                                                             'config' => [
                                                                 'template' => 'IWD_Opc/form/field-region',
                                                                 'additionalClasses' => 'float-left wd30-66 mr4'
@@ -863,7 +863,7 @@ class UpdateLayoutProcessor implements LayoutProcessorInterface
         } else if ($fieldCode === 'region_id') {
             $fieldConfig['label'] = new \Magento\Framework\Phrase('');
             $fieldConfig['sortOrder'] = '50';
-            $fieldConfig['placeholder'] = __('');
+            $fieldConfig['placeholder'] = '';
             $fieldConfig['component'] = 'IWD_Opc/js/form/element/region';
             $fieldConfig['config']['template'] = 'IWD_Opc/form/field-region';
             $fieldConfig['config']['elementTmpl'] = 'IWD_Opc/form/element/select';

--- a/Plugin/Block/LayoutProcessor.php
+++ b/Plugin/Block/LayoutProcessor.php
@@ -216,7 +216,7 @@ class LayoutProcessor
             $region_id = $jsLayoutResult['components']['checkout']['children']['steps']['children']['shipping-step']
             ['children']['shippingAddress']['children']['billing-address']['children']['form-fields']['children']['region_id'];
 
-            $region_id['label'] = new \Magento\Framework\Phrase('');
+            $region_id['label'] = '';
             $region_id['sortOrder'] = '50';
             $region_id['placeholder'] = '';
             $region_id['component'] = 'IWD_Opc/js/form/billing-address/element/region';

--- a/Plugin/Block/LayoutProcessor.php
+++ b/Plugin/Block/LayoutProcessor.php
@@ -218,7 +218,7 @@ class LayoutProcessor
 
             $region_id['label'] = new \Magento\Framework\Phrase('');
             $region_id['sortOrder'] = '50';
-            $region_id['placeholder'] = __('');
+            $region_id['placeholder'] = '';
             $region_id['component'] = 'IWD_Opc/js/form/billing-address/element/region';
             $region_id['config']['template'] = 'IWD_Opc/form/field';
             $region_id['config']['elementTmpl'] = 'IWD_Opc/form/billing-address/element/select';


### PR DESCRIPTION
When running this default magento command

bin/magento i18n:collect-phrases --magento

On the magento instance where your extension is installed, getting "Missed phrase" error.

More information about the error can be found in this article
https://magefan.com/magento-2-translation-extension/missed-phrase-error

This PR fixes the issue.